### PR TITLE
chore: update bio, about page, and switch to dark theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ email: damien@plenard.me
 url: https://damien.plenard.me
 description: Notes about my side projects.
 github_username: damoun
-minimal_mistakes_skin: default
+minimal_mistakes_skin: "dark"
 search: true
 
 # Build settings


### PR DESCRIPTION
## Summary

- Switch site theme to dark mode (`minimal_mistakes_skin: "dark"`)

## Test plan

- [ ] Verify site builds without errors
- [ ] Check About page renders correctly
- [ ] Confirm dark theme is applied across all pages