### PR TITLE
feat: upgrade Minimal Mistakes theme to v4.27.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,4 @@ group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jemoji"
   gem "jekyll-include-cache"
-  gem "jekyll-algolia"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -1,29 +1,20 @@
-# Welcome to Jekyll!
-#
-# This config file is meant for settings that affect your whole blog, values
-# which you are expected to set up once and rarely edit after that. If you find
-# yourself editing this file very often, consider using Jekyll's data files
-# feature for the data you need to update frequently.
-#
-# For technical reasons, this file is *NOT* reloaded automatically when you use
-# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
-
 # Site settings
-# These are used to personalize your new site. If you look in the HTML files,
-# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
-# You can create any custom variable you would like, and they will be accessible
-# in the templates via {{ site.myvariable }}.
 title: Notes
+title_separator: "-"
+subtitle: "Side projects & notes"
 email: damien@plenard.me
 url: https://damien.plenard.me
 description: Notes about my side projects.
+repository: "damoun/blog"
 github_username: damoun
 minimal_mistakes_skin: "dark"
 search: true
+enable_copy_code_button: true
+encoding: "utf-8"
 
 # Build settings
 markdown: kramdown
-remote_theme: mmistakes/minimal-mistakes
+remote_theme: mmistakes/minimal-mistakes@4.27.3
 # Outputting
 permalink: /:categories/:title/
 paginate: 5 # amount of posts to show
@@ -33,17 +24,14 @@ timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 include:
   - _pages
 
-# Exclude from processing.
-# The following items will not be processed, by default. Create a custom list
-# to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
 
 # Plugins (previously gems:)
 plugins:
@@ -74,6 +62,7 @@ author:
       url: "https://damoun.link"
 
 footer:
+  since: "2017"
   links:
     - label: "Status"
       icon: "fas fa-fw fa-info"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,5 +3,7 @@ main:
     url: /posts/
   - title: "Categories"
     url: /categories/
+  - title: "Tags"
+    url: /tags/
   - title: "About"
     url: /about/


### PR DESCRIPTION
- Pin remote_theme to mmistakes/minimal-mistakes@4.27.3
- Add enable_copy_code_button, title_separator, subtitle, encoding
- Add repository field for GitHub metadata integration
- Add footer.since for copyright year range display
- Uncomment and enable exclude list for clean builds
- Remove unused jekyll-algolia gem from Gemfile
- Add Tags link to navigation

https://claude.ai/code/session_01NUJWRPodcYodujeD3iGFFs