### PR TITLE
feat: enable giscus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,6 +79,17 @@ footer:
       icon: "fas fa-fw fa-info"
       url: "https://status.damoun.cloud"
 
+comments:
+  provider: "giscus"
+  giscus:
+    repo_id: "MDEwOlJlcG9zaXRvcnk0MDQ0Nzc4NDE="
+    category_name: "Comments"
+    category_id: "DIC_kwDOGBvXkc4C4CvO"
+    discussion_term: "og:title"
+    reactions_enabled: "1"
+    theme: "dark"
+    lang: "en"
+
 defaults:
   # _posts
   - scope:


### PR DESCRIPTION
Add Giscus comments support via Minimal Mistakes built-in provider config.