### PR TITLE
Set timezone to Europe/Amsterdam

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ remote_theme: mmistakes/minimal-mistakes@4.27.3
 permalink: /:categories/:title/
 paginate: 5 # amount of posts to show
 paginate_path: /page:num/
-timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+timezone: Europe/Amsterdam # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 include:
   - _pages


### PR DESCRIPTION
## Summary

- Configure Jekyll timezone to `Europe/Amsterdam` to ensure posts are built with the correct local date